### PR TITLE
Add unique id's for all entities

### DIFF
--- a/custom_components/uhomeuponor/__init__.py
+++ b/custom_components/uhomeuponor/__init__.py
@@ -269,7 +269,7 @@ class UhomeThermostat(object):
         self.uhome_thermostat_keys = {}
         self.uc_index = uc_index
         self.index = index
+        self.identity = "controller" + str(uc_index) + "_thermostat" + str(index)
         for key_name, key_data in UHOME_THERMOSTAT_KEYS.items():
             # address in calculated with following: addr + (500 x controller_index) + (40 x thermostat_index)
             self.uhome_thermostat_keys[key_name] = {'addr': (key_data['addr'] + (500 * uc_index) + (40 * index)), 'value': 0}
-

--- a/custom_components/uhomeuponor/climate.py
+++ b/custom_components/uhomeuponor/climate.py
@@ -58,6 +58,15 @@ class UHomeClimateThermostat(ClimateDevice, Uhome):
         self.thermostat = thermostat
         self._preset_mode = None
         self._hvac_mode = None
+        
+        self.identity = thermostat.identity + "_thermostat"
+        if not prefix is None:
+            self.identity = str(prefix) + self.identity
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.identity
 
     @property
     def available(self):
@@ -199,6 +208,15 @@ class GeneralClimateThermostat(ClimateDevice, Uhome):
         self.uhome = uhome
         self._preset_mode = None
         self._hvac_mode = None
+
+        self.identity = "general"
+        if not prefix is None:
+            self.identity = str(prefix) + self.identity
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.identity
 
     @property
     def available(self):

--- a/custom_components/uhomeuponor/sensor.py
+++ b/custom_components/uhomeuponor/sensor.py
@@ -43,8 +43,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
     _LOGGER.info("finish setup platform sensor Uhome Uponor")
 
-
-
 class UHomeRHSensor(Entity, Uhome):
     """Representation of a Sensor."""
 
@@ -54,6 +52,15 @@ class UHomeRHSensor(Entity, Uhome):
         self.prefix = prefix
         self.uhome = uhome
         self.thermostat = thermostat
+
+        self.identity = thermostat.identity + "_rh"
+        if not prefix is None:
+            self.identity = str(prefix) + self.identity
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.identity
 
     @property
     def name(self):
@@ -117,6 +124,15 @@ class UHomeSensor(Entity, Uhome):
         self.prefix = prefix
         self.uhome = uhome
         self.thermostat = thermostat
+        
+        self.identity = thermostat.identity + "_temp"
+        if not prefix is None:
+            self.identity = str(prefix) + self.identity
+
+    @property
+    def unique_id(self):
+        """Return a unique ID."""
+        return self.identity
 
     @property
     def name(self):


### PR DESCRIPTION
Fixes #3

This change adds unique_ids to all entities, ensuring they're registered in the Entity registry. Once they are that, changes made by users will persist across HA restarts. As it is now, I cannot change the sensor name of any sensor made by this integration, as the change would be lost (HA also disallows it for this reason).

For unique id's, I've used the thermostats logical positions within controllers and connections. An example name is `controller1_thermostat4`. The prefix is used, so it ends up being `PREFIXcontroller1_thermostat4_temp` for the temperature sensor at controller 2, thermostat 5.

With this change, my entity registry looks like this.

![image](https://user-images.githubusercontent.com/1027111/72842937-d20dbd00-3c99-11ea-9252-fbfcd3f7733e.png)
