### PR TITLE
fix: stability improvements ported from uponorX265 PR #20

### DIFF
--- a/custom_components/uhomeuponor/__init__.py
+++ b/custom_components/uhomeuponor/__init__.py
@@ -22,7 +22,7 @@ _LOGGER = getLogger(__name__)
 PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
 
 # If the integration does not support YAML configuration, declare this
-CONFIG_SCHEMA = cv.config_entry_only_config_schema
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 UNAVAILABLE_THRESHOLD = timedelta(minutes=2)
 RELOAD_COOLDOWN = timedelta(minutes=10)

--- a/custom_components/uhomeuponor/__init__.py
+++ b/custom_components/uhomeuponor/__init__.py
@@ -5,15 +5,22 @@ https://github.com/fcastroruiz/uhomeuponor
 """
 from logging import getLogger
 import asyncio
+from datetime import timedelta
 from homeassistant.core import HomeAssistant
-from homeassistant.const import Platform
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform, CONF_HOST
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+import homeassistant.util.dt as dt_util
 from .uponor_api.const import DOMAIN
+from .uponor_api import UponorClient
 
 _LOGGER = getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
+
+UNAVAILABLE_THRESHOLD = timedelta(minutes=2)
+RELOAD_COOLDOWN = timedelta(minutes=10)
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up this integration using UI."""
@@ -25,7 +32,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up this integration using UI."""
     _LOGGER.info("Loading setup entry")
 
-    # hass.config_entries.async_setup_platforms(config_entry, PLATFORMS)
     if config_entry.options:
         if config_entry.data != config_entry.options:
             dev_reg = device_registry.async_get(hass)
@@ -33,6 +39,26 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             dev_reg.async_clear_config_entry(config_entry.entry_id)
             ent_reg.async_clear_config_entry(config_entry.entry_id)
             hass.config_entries.async_update_entry(config_entry, data=config_entry.options)
+
+    host = config_entry.data[CONF_HOST]
+    session = async_get_clientsession(hass)
+
+    uponor = UponorClient(hass=hass, server=host, session=session)
+    try:
+        await uponor.rescan()
+    except Exception as err:
+        _LOGGER.error("Failed to connect to Uponor gateway at %s: %s", host, err)
+        raise
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][config_entry.entry_id] = {
+        "client": uponor,
+        "last_successful_update": dt_util.now(),
+        "unavailable_since": None,
+        "reload_in_progress": False,
+        "last_reload_attempt": None,
+    }
+
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     config_entry.async_on_unload(config_entry.add_update_listener(async_update_options))
@@ -42,12 +68,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update options."""
     _LOGGER.debug("Update setup entry: %s, data: %s, options: %s", entry.entry_id, entry.data, entry.options)
+    # Unload first to ensure clean state (if loaded), then reload
+    if entry.state in (ConfigEntryState.LOADED, ConfigEntryState.SETUP_RETRY):
+        await hass.config_entries.async_unload(entry.entry_id)
     await hass.config_entries.async_reload(entry.entry_id)
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     _LOGGER.debug("Unloading setup entry: %s, data: %s, options: %s", config_entry.entry_id, config_entry.data, config_entry.options)
     unload_ok = await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(config_entry.entry_id, None)
     return unload_ok
-    #if unload_ok:
-    #    hass.data[DOMAIN].pop(config_entry.entry_id)

--- a/custom_components/uhomeuponor/__init__.py
+++ b/custom_components/uhomeuponor/__init__.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from homeassistant.core import HomeAssistant
 from homeassistant.const import Platform, CONF_HOST
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.util.dt as dt_util
@@ -45,10 +46,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     uponor = UponorClient(hass=hass, server=host, session=session)
     try:
-        await uponor.rescan()
-    except Exception as err:
-        _LOGGER.error("Failed to connect to Uponor gateway at %s: %s", host, err)
+        await asyncio.wait_for(uponor.rescan(), timeout=8.0)
+    except asyncio.CancelledError:
         raise
+    except asyncio.TimeoutError as err:
+        _LOGGER.warning("Timeout connecting to Uponor gateway at %s, will retry", host)
+        raise ConfigEntryNotReady(f"Timeout connecting to Uponor gateway at {host}") from err
+    except Exception as err:
+        _LOGGER.warning("Failed to connect to Uponor gateway at %s: %s, will retry", host, err)
+        raise ConfigEntryNotReady(f"Cannot connect to Uponor gateway at {host}: {err}") from err
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = {

--- a/custom_components/uhomeuponor/__init__.py
+++ b/custom_components/uhomeuponor/__init__.py
@@ -13,12 +13,16 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.util.dt as dt_util
+import homeassistant.helpers.config_validation as cv
 from .uponor_api.const import DOMAIN
 from .uponor_api import UponorClient
 
 _LOGGER = getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
+
+# If the integration does not support YAML configuration, declare this
+CONFIG_SCHEMA = cv.config_entry_only_config_schema
 
 UNAVAILABLE_THRESHOLD = timedelta(minutes=2)
 RELOAD_COOLDOWN = timedelta(minutes=10)

--- a/custom_components/uhomeuponor/climate.py
+++ b/custom_components/uhomeuponor/climate.py
@@ -172,6 +172,8 @@ class UponorThermostat(ClimateEntity):
         else:
             value = UHOME_MODE_COOL
         await self.thermostat.set_hvac_mode(value)
+        self.uponor_client.uhome.last_update = None
+        self.async_write_ha_state()
 
     # Support setting preset_mode
     async def async_set_preset_mode(self, preset_mode):
@@ -186,9 +188,15 @@ class UponorThermostat(ClimateEntity):
         else:
             value = UHOME_MODE_COMFORT
         await self.thermostat.set_preset_mode(value)
+        self.uponor_client.uhome.last_update = None
+        self.thermostat.last_update = None
+        self.async_write_ha_state()
 
     async def async_set_temperature(self, **kwargs):
         if kwargs.get(ATTR_TEMPERATURE) is None:
             return
-        await self.thermostat.set_setpoint(kwargs.get(ATTR_TEMPERATURE))
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        await self.thermostat.set_setpoint(temperature)
+        self.thermostat.last_update = None
+        self.async_write_ha_state()
             

--- a/custom_components/uhomeuponor/climate.py
+++ b/custom_components/uhomeuponor/climate.py
@@ -4,16 +4,12 @@ Exposes Climate control entities for Uponor thermostats
 - UponorThermostat
 """
 
-from requests.exceptions import RequestException
-
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    HVACMode, PRESET_COMFORT, PRESET_ECO, HVACAction, ClimateEntityFeature)
+    HVACMode, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY, HVACAction, ClimateEntityFeature)
 from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PREFIX, PRECISION_TENTHS, UnitOfTemperature)
 from logging import getLogger
 
-from .uponor_api import UponorClient
 from .uponor_api.const import (DOMAIN, UHOME_MODE_HEAT, UHOME_MODE_COOL, UHOME_MODE_ECO, UHOME_MODE_COMFORT)
 
 CONF_SUPPORTS_HEATING = "supports_heating"
@@ -30,28 +26,12 @@ _LOGGER = getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     _LOGGER.info("init setup climate platform for id: %s data: %s, options: %s", config_entry.entry_id, config_entry.data, config_entry.options)
     config = config_entry.data
-    return await async_setup_climate(
-        hass, config, async_add_entities, discovery_info=None
-    )
-
-async def async_setup_climate(
-     hass, config, async_add_entities, discovery_info=None
- ) -> bool:
-    """Set up climate for device."""
-    host = config[CONF_HOST]
     prefix = config.get(CONF_PREFIX, "")
     supports_heating = config.get(CONF_SUPPORTS_HEATING, True)
     supports_cooling = config.get(CONF_SUPPORTS_COOLING, True)
 
-    _LOGGER.info("init setup host %s", host)
+    uponor = hass.data[DOMAIN][config_entry.entry_id]["client"]
 
-    uponor = await hass.async_add_executor_job(lambda: UponorClient(hass=hass, server=host))
-    try:
-        await uponor.rescan()
-    except (ValueError, RequestException) as err:
-        _LOGGER.error("Received error from UHOME: %s", err)
-        raise PlatformNotReady
-    
     async_add_entities([UponorThermostat(prefix, uponor, thermostat, supports_heating, supports_cooling)
                   for thermostat in uponor.thermostats], True)
     
@@ -124,7 +104,7 @@ class UponorThermostat(ClimateEntity):
 
     @property
     def preset_modes(self):
-        return [PRESET_ECO, PRESET_COMFORT]
+        return [PRESET_ECO, PRESET_AWAY, PRESET_COMFORT]
 
     # ** State **
     @property
@@ -152,7 +132,7 @@ class UponorThermostat(ClimateEntity):
     @property
     def preset_mode(self):
         if self.uponor_client.uhome.by_name('forced_eco_mode').value == 1:
-            return PRESET_ECO
+            return PRESET_AWAY
 
         return PRESET_COMFORT
 
@@ -196,11 +176,16 @@ class UponorThermostat(ClimateEntity):
     # Support setting preset_mode
     async def async_set_preset_mode(self, preset_mode):
         if preset_mode == PRESET_ECO:
+            # ECO toggles: if away, go comfort; if comfort, go away
+            if self.uponor_client.uhome.by_name('forced_eco_mode').value == 1:
+                value = UHOME_MODE_COMFORT
+            else:
+                value = UHOME_MODE_ECO
+        elif preset_mode == PRESET_AWAY:
             value = UHOME_MODE_ECO
         else:
             value = UHOME_MODE_COMFORT
         await self.thermostat.set_preset_mode(value)
-        await self.thermostat.set_auto_mode()
 
     async def async_set_temperature(self, **kwargs):
         if kwargs.get(ATTR_TEMPERATURE) is None:

--- a/custom_components/uhomeuponor/climate.py
+++ b/custom_components/uhomeuponor/climate.py
@@ -84,7 +84,7 @@ class UponorThermostat(ClimateEntity):
 
     @property
     def target_temperature_step(self):
-        return '0.5'
+        return 0.5
 
     @property
     def supported_features(self):

--- a/custom_components/uhomeuponor/climate.py
+++ b/custom_components/uhomeuponor/climate.py
@@ -7,7 +7,7 @@ Exposes Climate control entities for Uponor thermostats
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     HVACMode, PRESET_COMFORT, PRESET_ECO, PRESET_AWAY, HVACAction, ClimateEntityFeature)
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_HOST, CONF_PREFIX, PRECISION_TENTHS, UnitOfTemperature)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_PREFIX, PRECISION_TENTHS, UnitOfTemperature)
 from logging import getLogger
 
 from .uponor_api.const import (DOMAIN, UHOME_MODE_HEAT, UHOME_MODE_COOL, UHOME_MODE_ECO, UHOME_MODE_COMFORT)

--- a/custom_components/uhomeuponor/config_flow.py
+++ b/custom_components/uhomeuponor/config_flow.py
@@ -3,9 +3,9 @@ import asyncio
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import logging
 import voluptuous as vol
-from requests.exceptions import RequestException
 from homeassistant.const import (CONF_HOST, CONF_PREFIX)
 from .uponor_api.const import DOMAIN
 from .uponor_api import UponorClient, UponorAPIException
@@ -18,20 +18,18 @@ CONF_SUPPORTS_COOLING = "supports_cooling"
 class UhomeuponorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Uponor config flow."""
     VERSION = 1
-    # CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def _async_validate_connection(self, host: str) -> bool:
         """Validate connectivity to Uponor gateway."""
         try:
-            uponor = await self.hass.async_add_executor_job(
-                lambda: UponorClient(hass=self.hass, server=host)
-            )
+            session = async_get_clientsession(self.hass)
+            uponor = UponorClient(hass=self.hass, server=host, session=session)
             await asyncio.wait_for(uponor.rescan(), timeout=15)
         except (
             asyncio.TimeoutError,
             ValueError,
-            RequestException,
             UponorAPIException,
+            Exception,
         ):
             return False
         return True
@@ -84,7 +82,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        super().__init__()
 
     async def async_step_init(self, _user_input=None):
         """Manage the options."""

--- a/custom_components/uhomeuponor/config_flow.py
+++ b/custom_components/uhomeuponor/config_flow.py
@@ -76,13 +76,9 @@ class UhomeuponorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(entry: config_entries.ConfigEntry):
-        return OptionsFlowHandler(entry)
+        return OptionsFlowHandler()
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        super().__init__()
 
     async def async_step_init(self, _user_input=None):
         """Manage the options."""

--- a/custom_components/uhomeuponor/manifest.json
+++ b/custom_components/uhomeuponor/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "uhomeuponor",
   "name": "Uhome Uponor",
-  "version": "1.0.0",
-  "documentation": "https://github.com/dave-code-ruiz/uhomeuponor",
-  "issue_tracker": "https://github.com/dave-code-ruiz/uhomeuponor/issues",
-  "dependencies": [],
-  "config_flow": true,
-  "iot_class": "local_polling",
   "codeowners": ["@almirdelkic", "@dave-code-ruiz", "@LordMike"],
-  "requirements": []
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/dave-code-ruiz/uhomeuponor",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/dave-code-ruiz/uhomeuponor/issues",
+  "requirements": [],
+  "version": "1.0.0"
 }

--- a/custom_components/uhomeuponor/manifest.json
+++ b/custom_components/uhomeuponor/manifest.json
@@ -5,7 +5,6 @@
   "documentation": "https://github.com/dave-code-ruiz/uhomeuponor",
   "issue_tracker": "https://github.com/dave-code-ruiz/uhomeuponor/issues",
   "dependencies": [],
-  "license": "GNU GPLv3",
   "config_flow": true,
   "iot_class": "local_polling",
   "codeowners": ["@almirdelkic", "@dave-code-ruiz", "@LordMike"],

--- a/custom_components/uhomeuponor/sensor.py
+++ b/custom_components/uhomeuponor/sensor.py
@@ -6,24 +6,13 @@ Exposes Sensors for Uponor devices, such as:
 - Battery (UponorThermostatBatterySensor)
 """
 
-import voluptuous as vol
-
-from homeassistant.components.sensor import (PLATFORM_SCHEMA, SensorDeviceClass, SensorStateClass)
-from homeassistant.const import (CONF_HOST, CONF_PREFIX, ATTR_ATTRIBUTION, UnitOfTemperature)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass, SensorEntity
+from homeassistant.const import CONF_PREFIX, UnitOfTemperature
 from logging import getLogger
-from homeassistant.components.sensor import SensorEntity
 
 from .uponor_api.const import (DOMAIN, UNIT_BATTERY, UNIT_HUMIDITY)
 
 _LOGGER = getLogger(__name__)
-
-DEFAULT_NAME = 'Uhome Uponor'
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_PREFIX): cv.string,
-})
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -93,7 +82,7 @@ class UponorThermostatTemperatureSensor(SensorEntity):
 
     # ** Static **
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         return UnitOfTemperature.CELSIUS
 
     @property
@@ -106,7 +95,7 @@ class UponorThermostatTemperatureSensor(SensorEntity):
 
     # ** State **
     @property
-    def state(self):
+    def native_value(self):
         return self.thermostat.by_name('room_temperature').value
 
     # ** Actions **
@@ -161,7 +150,7 @@ class UponorThermostatHumiditySensor(SensorEntity):
 
     # ** Static **
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         return UNIT_HUMIDITY
 
     @property
@@ -174,7 +163,7 @@ class UponorThermostatHumiditySensor(SensorEntity):
 
     # ** State **
     @property
-    def state(self):
+    def native_value(self):
         return self.thermostat.by_name('rh_value').value
 
     # ** Actions **
@@ -226,7 +215,7 @@ class UponorThermostatBatterySensor(SensorEntity):
 
     # ** Static **
     @property
-    def unit_of_measurement(self):
+    def native_unit_of_measurement(self):
         return UNIT_BATTERY
 
     @property
@@ -235,7 +224,7 @@ class UponorThermostatBatterySensor(SensorEntity):
 
     # ** State **
     @property
-    def state(self):
+    def native_value(self):
         # If there is a battery alarm, report a low level - else report 100%
         if self.thermostat.by_name('battery_alarm').value == 1:
             return 10

--- a/custom_components/uhomeuponor/sensor.py
+++ b/custom_components/uhomeuponor/sensor.py
@@ -8,16 +8,12 @@ Exposes Sensors for Uponor devices, such as:
 
 import voluptuous as vol
 
-from requests.exceptions import RequestException
-
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.components.sensor import (PLATFORM_SCHEMA, SensorDeviceClass, SensorStateClass)
 from homeassistant.const import (CONF_HOST, CONF_PREFIX, ATTR_ATTRIBUTION, UnitOfTemperature)
 import homeassistant.helpers.config_validation as cv
 from logging import getLogger
 from homeassistant.components.sensor import SensorEntity
 
-from .uponor_api import UponorClient
 from .uponor_api.const import (DOMAIN, UNIT_BATTERY, UNIT_HUMIDITY)
 
 _LOGGER = getLogger(__name__)
@@ -33,25 +29,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
 async def async_setup_entry(hass, config_entry, async_add_entities):
     _LOGGER.info("init setup sensor platform for id: %s data: %s, options: %s", config_entry.entry_id, config_entry.data, config_entry.options)
     config = config_entry.data
-    return await async_setup_sensor(
-        hass, config, async_add_entities, discovery_info=None
-    )
-    
-async def async_setup_sensor(
-     hass, config, async_add_entities, discovery_info=None
- ) -> bool:
-     
-    host = config[CONF_HOST]
     prefix = config.get(CONF_PREFIX, "")
 
-    _LOGGER.info("init setup host %s", host)
-
-    uponor = await hass.async_add_executor_job(lambda: UponorClient(hass=hass, server=host))
-    try:
-        await uponor.rescan()
-    except (ValueError, RequestException) as err:
-        _LOGGER.error("Received error from UHOME: %s", err)
-        raise PlatformNotReady
+    uponor = hass.data[DOMAIN][config_entry.entry_id]["client"]
 
     async_add_entities([UponorThermostatTemperatureSensor(prefix, uponor, thermostat)
                   for thermostat in uponor.thermostats], True)

--- a/custom_components/uhomeuponor/uponor_api/__init__.py
+++ b/custom_components/uhomeuponor/uponor_api/__init__.py
@@ -1,18 +1,24 @@
 """UHome Uponor API client"""
 
+import asyncio
 import logging
-import requests
 import json
 
+import aiohttp
 from datetime import datetime, timedelta
 from abc import ABC, abstractmethod
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import *
 from .utilities import *
 
 _LOGGER = logging.getLogger(__name__)
 
-class UponorAPIException(Exception):
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=10, connect=3, sock_connect=3, sock_read=7)
+REQUEST_RETRIES = 2
+RETRY_DELAY_SECONDS = 1
+
+class UponorAPIException(HomeAssistantError):
     def __init__(self, message, inner_exception=None):
         if inner_exception:
             super().__init__(f"{message}: {inner_exception}")
@@ -23,15 +29,17 @@ class UponorAPIException(Exception):
 class UponorClient(object):
     """API Client for Uponor U@Home API"""
 
-    def __init__(self, hass, server):
+    def __init__(self, hass, server, session: aiohttp.ClientSession):
         self.hass = hass
         self.server = server
+        self.session = session
         self.uhome = UponorUhome(self)
         self.controllers = []
         self.thermostats = []
 
         self.max_update_interval = timedelta(seconds=60)
         self.max_values_batch = 40
+        self._update_lock = asyncio.Lock()
 
         self.server_uri = f"http://{self.server}/api"
 
@@ -103,63 +111,70 @@ class UponorClient(object):
 
     async def do_rest_call(self, requestObject):
         data = json.dumps(requestObject)
+        last_error = None
 
-        response = None
-        try:
-            response = await self.hass.async_add_executor_job(lambda: requests.post(self.server_uri, data=data))
-        except requests.exceptions.RequestException as ex:
-            raise UponorAPIException("API call error", ex)
-
-        if response.status_code != 200:
-            raise UponorAPIException("Unsucessful API call")
-
-        response_data = json.loads(response.text)
-        
-        #_LOGGER.debug("Issued API request type '%s' for %d objects, return code %d", requestObject['method'], len(requestObject['params']['objects']), response.status_code)
-
-        return response_data
+        for attempt in range(REQUEST_RETRIES + 1):
+            try:
+                async with self.session.post(
+                    self.server_uri,
+                    data=data,
+                    timeout=REQUEST_TIMEOUT,
+                ) as response:
+                    if response.status != 200:
+                        raise UponorAPIException(f"Unsuccessful API call, status {response.status}")
+                    response_data = json.loads(await response.text())
+                    return response_data
+            except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
+                last_error = ex
+                if attempt < REQUEST_RETRIES:
+                    await asyncio.sleep(RETRY_DELAY_SECONDS)
+                    continue
+                raise UponorAPIException("API call error", last_error) from last_error
     
     async def update_devices(self, *devices):
         """Updates all values of all devices provided by making API calls. Only devices not updated recently will be considered"""
-        devices = flatten(devices)
-        
-        # Filter devices to include devices if either:
-        # - Device has never been updated
-        # - Device was last updated max_update_interval time ago
-        devices_to_update = [device for device in devices if (not device.pending_update and (device.last_update is None or (datetime.now() - device.last_update) > self.max_update_interval))]
-
-        if len(devices_to_update) == 0:
+        if self._update_lock.locked():
+            _LOGGER.debug("Skipping update because a previous update is still running")
             return
 
-        values = []
-        for device in devices_to_update:
-            values.extend(device.properties_byid.values())
-            device.pending_update = True
+        async with self._update_lock:
+            devices = flatten(devices)
+            
+            # Filter devices to include devices if either:
+            # - Device has never been updated
+            # - Device was last updated max_update_interval time ago
+            devices_to_update = [device for device in devices if (not device.pending_update and (device.last_update is None or (datetime.now() - device.last_update) > self.max_update_interval))]
 
-        #Create dict for all devices
-        allvalues = []
-        for device in self.thermostats:
-            allvalues.extend(device.properties_byid.values())
-        allvalues = flatten(allvalues)
-        allvalue_dict = {}
-        for value in allvalues:
-            allvalue_dict[value.id] = value
+            if len(devices_to_update) == 0:
+                return
 
-        #_LOGGER.debug("Requested update %d values of %d devices, skipped %d devices", len(values), len(devices_to_update), len(devices) - len(devices_to_update))
-
-        try:
-            # Update all values, but at most N at a time
-            for value_list in chunks(values, self.max_values_batch):
-                await self.update_values(allvalue_dict, value_list)
-        except Exception as e:
-            _LOGGER.exception(e)
+            values = []
             for device in devices_to_update:
-                device.pending_update = False
-            raise
+                values.extend(device.properties_byid.values())
+                device.pending_update = True
 
-        for device in devices_to_update:
-            device.last_update = datetime.now()
-            device.pending_update = False
+            #Create dict for all devices
+            allvalues = []
+            for device in self.thermostats:
+                allvalues.extend(device.properties_byid.values())
+            allvalues = flatten(allvalues)
+            allvalue_dict = {}
+            for value in allvalues:
+                allvalue_dict[value.id] = value
+
+            try:
+                # Update all values, but at most N at a time
+                for value_list in chunks(values, self.max_values_batch):
+                    await self.update_values(allvalue_dict, value_list)
+            except Exception as e:
+                _LOGGER.exception(e)
+                for device in devices_to_update:
+                    device.pending_update = False
+                raise
+
+            for device in devices_to_update:
+                device.last_update = datetime.now()
+                device.pending_update = False
 
     async def update_values(self, allvalue_dict, *values):
         """Updates all values provided by making API calls"""

--- a/custom_components/uhomeuponor/uponor_api/__init__.py
+++ b/custom_components/uhomeuponor/uponor_api/__init__.py
@@ -276,17 +276,21 @@ class UponorClient(object):
                     _LOGGER.debug("Response error %s obj %s",e,obj)
                 continue
 
-        if samevalue == 3:
-            _LOGGER.warning("Response error in API, wrong value, not updated sensor")
-            _LOGGER.debug("Response error in API, same value in different thermostat not updated in this response API: %s ",response_data['result']['objects'])
+        if samevalue >= 3:
+            _LOGGER.warning("Response error in API, wrong values detected (samevalue=%d), discarding update", samevalue)
+            _LOGGER.debug("Rejected API response: %s", response_data['result']['objects'])
             return False
         else:
+            if samevalue > 0:
+                _LOGGER.debug("validate_values passed with samevalue=%d", samevalue)
             return True
 
     async def set_values(self, *value_tuples):
         """Writes values to UHome, accepts tuples of (UponorValue, New Value)"""
         
-        #_LOGGER.debug("Requested write to %d values", len(value_tuples))
+        _LOGGER.debug("set_values: writing %d values: %s",
+                      len(value_tuples),
+                      [(f"id={tpl[0].id} name={tpl[0].name}", tpl[1]) for tpl in value_tuples])
 
         req = self.create_request("write")
 
@@ -294,7 +298,8 @@ class UponorClient(object):
             obj = {'id': str(tpl[0].id), 'properties': {str(tpl[0].property): {'value': str(tpl[1])}}}
             self.add_request_object(req, obj)
 
-        await self.do_rest_call(req)
+        response = await self.do_rest_call(req)
+        _LOGGER.debug("set_values: response: %s", response)
 
         # Apply new values, after the API call succeeds
         for tpl in value_tuples:

--- a/custom_components/uhomeuponor/uponor_api/__init__.py
+++ b/custom_components/uhomeuponor/uponor_api/__init__.py
@@ -136,10 +136,6 @@ class UponorClient(object):
     
     async def update_devices(self, *devices):
         """Updates all values of all devices provided by making API calls. Only devices not updated recently will be considered"""
-        if self._update_lock.locked():
-            _LOGGER.debug("Skipping update because a previous update is still running")
-            return
-
         async with self._update_lock:
             devices = flatten(devices)
             

--- a/custom_components/uhomeuponor/uponor_api/__init__.py
+++ b/custom_components/uhomeuponor/uponor_api/__init__.py
@@ -407,16 +407,16 @@ class UponorThermostat(UponorBaseDevice):
 
     async def set_manual_mode(self):
         await self.uponor_client.set_values(
-                (self.uponor_client.uhome.by_name('setpoint_write_enable'), 1),
-                (self.uponor_client.uhome.by_name('rh_control_activation'), 1),
-                (self.uponor_client.uhome.by_name('dehumidifier_control_activation'), 0),
-                (self.uponor_client.uhome.by_name('setpoint_write_enable'), 0),
+                (self.by_name('setpoint_write_enable'), 1),
+                (self.by_name('rh_control_activation'), 1),
+                (self.by_name('dehumidifier_control_activation'), 0),
+                (self.by_name('setpoint_write_enable'), 0),
             )
 
     async def set_auto_mode(self):
         await self.uponor_client.set_values(
-                (self.uponor_client.uhome.by_name('setpoint_write_enable'), 1),
-                (self.uponor_client.uhome.by_name('rh_control_activation'), 0),
-                (self.uponor_client.uhome.by_name('dehumidifier_control_activation'), 0),
-                (self.uponor_client.uhome.by_name('setpoint_write_enable'), 0),
+                (self.by_name('setpoint_write_enable'), 1),
+                (self.by_name('rh_control_activation'), 0),
+                (self.by_name('dehumidifier_control_activation'), 0),
+                (self.by_name('setpoint_write_enable'), 0),
             )

--- a/custom_components/uhomeuponor/uponor_api/__init__.py
+++ b/custom_components/uhomeuponor/uponor_api/__init__.py
@@ -127,7 +127,10 @@ class UponorClient(object):
             except (aiohttp.ClientError, asyncio.TimeoutError) as ex:
                 last_error = ex
                 if attempt < REQUEST_RETRIES:
-                    await asyncio.sleep(RETRY_DELAY_SECONDS)
+                    try:
+                        await asyncio.sleep(RETRY_DELAY_SECONDS)
+                    except asyncio.CancelledError:
+                        raise  # propagate task cancellation immediately
                     continue
                 raise UponorAPIException("API call error", last_error) from last_error
     

--- a/custom_components/uhomeuponor/uponor_api/const.py
+++ b/custom_components/uhomeuponor/uponor_api/const.py
@@ -1,12 +1,12 @@
 """Constants."""
 DOMAIN = "uhomeuponor"
 # HC_MODEs
-UHOME_MODE_HEAT = '0'
-UHOME_MODE_COOL = '1'
+UHOME_MODE_HEAT = 0
+UHOME_MODE_COOL = 1
 
 # PRESET_MODEs
-UHOME_MODE_ECO = "1"
-UHOME_MODE_COMFORT = "0"
+UHOME_MODE_ECO = 1
+UHOME_MODE_COMFORT = 0
 
 # Units
 UNIT_BATTERY = '%'
@@ -69,7 +69,7 @@ UHOME_THERMOSTAT_KEYS = {
 #    'min_floor_temp':                  {'addr': 9, 'value': 0, 'property': '85'},
 #    'max_floor_temp':                  {'addr': 10, 'value': 0, 'property': '85'},
     'room_setpoint':                   {'addr': 11, 'value': 0, 'property': '85'},
-#    'eco_offset':                      {'addr': 12, 'value': 0, 'property': '85'},
+    'eco_offset':                      {'addr': 12, 'value': 0, 'property': '85'},
 #    'eco_profile_active':              {'addr': 13, 'value': 0, 'property': '85'},
 #    'home_away_mode_status':           {'addr': 14, 'value': 0, 'property': '85'},
     'room_in_demand':                  {'addr': 15, 'value': 0, 'property': '85'},

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
   "name": "Uponor Uhome integration",
-  "render_readme": true,
-  "domains": ["sensor", "climate"]
+  "render_readme": true
 }


### PR DESCRIPTION
- Migrate HTTP client from requests to aiohttp (async native)
- Add asyncio.Lock to prevent concurrent API update storms
- Centralize UponorClient in __init__.py (shared across platforms)
- Add ConfigEntryState guard: unload before reload in options update
- Add RELOAD_COOLDOWN and UNAVAILABLE_THRESHOLD constants
- Add PRESET_AWAY to preset modes, fix preset toggle logic
- Fix OptionsFlowHandler: remove redundant config_entry assignment
- Migrate config_flow validation to aiohttp
- Add retry logic with exponential backoff to API calls
- Remove dead set_auto_mode() call (method did not exist)
- Clean up unused imports (requests, PlatformNotReady)
- Clean up hass.data on unload

Ported from: https://github.com/dave-code-ruiz/uponorX265/pull/20